### PR TITLE
update comment serializer to edit comment

### DIFF
--- a/groupProjectBackend/articles/serializers.py
+++ b/groupProjectBackend/articles/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from .models import Articles, Category, Comment
 from django.contrib.auth import get_user_model
+from users.models import CustomUser
 
 User = get_user_model()
 
@@ -10,18 +11,19 @@ class CommentSerializer(serializers.Serializer):
     comment = serializers.CharField(max_length=200)
     anonymous = serializers.BooleanField()
     articles_id = serializers.IntegerField()
-    supporter = serializers.ReadOnlyField(source='supporter.id')
+    # supporter = serializers.ReadOnlyField(source='supporter.id')
 
     def create(self, validated_data):
         return Comment.objects.create(**validated_data)
 
 class CommentDetailSerializer(CommentSerializer):
     
-    def update(self, instance,validated_data):
+    def update(self, instance, validated_data):
         instance.comment = validated_data.get('comment', instance.comment)
         instance.anonymous = validated_data.get('anonymous', instance.anonymous)
         instance.articles_id = validated_data.get('articles_id', instance.articles_id)
-        instance.supporter = validated_data.get('supporter', instance.supporter_id)
+        # instance.supporter = validated_data.get('supporter', instance.supporter_id)
+        return instance
 
 class ArticlesSerializer(serializers.Serializer):
     id = serializers.ReadOnlyField()

--- a/groupProjectBackend/articles/views.py
+++ b/groupProjectBackend/articles/views.py
@@ -21,7 +21,7 @@ class CommentList(APIView):
     def post(self, request):
         serializer = CommentSerializer(data=request.data)
         if serializer.is_valid():
-            serializer.save(supporter=request.user)
+            serializer.save(user=request.user)
             return Response(
                 serializer.data,
                 status=status.HTTP_201_CREATED
@@ -29,8 +29,9 @@ class CommentList(APIView):
         return Response(serializer.errors,status=status.HTTP_400_BAD_REQUEST)
 
 class CommentDetail(APIView):
-    # permission_classes = [
-    #     permissions.IsAuthenticatedOrReadOnly,
+    permission_classes = [
+        permissions.IsAuthenticatedOrReadOnly,
+    ]
     #     IsOwnerOrReadOnly
     # ]
     # I've commented this out and it has solved my attribute error of comment not having an owner. In serializers, there is a supporter
@@ -53,7 +54,7 @@ class CommentDetail(APIView):
         comment = self.get_object(pk)
         data = request.data
         serializer = CommentDetailSerializer(
-            instance=articles,
+            instance=comment,
             data=data,
             partial=True
         )


### PR DESCRIPTION
Have temporarily commented out support element in comment serializers. However, a user can now edit their comment 

![image](https://user-images.githubusercontent.com/94447333/171094787-71a81248-d60b-48a9-8a67-02116cc12fe0.png)
